### PR TITLE
Add missing current field in EBNF

### DIFF
--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -34,7 +34,7 @@ windspeed   = "W", [ decimal ], [ ",", [ decimal ] ];
 location    = "L", ( ( [ decimal, ",", decimal ] ) | ","), [ ",", [ decimal ] ];
 zombie      = "Z", ( "0" | "1" );
 
-data field  = voltage | temperature | humidity | pressure | custom | sun |
+data field  = voltage | current | temperature | humidity | pressure | custom | sun |
               rssi | windspeed | location | count | zombie;
 
 data = { data field };


### PR DESCRIPTION
This is defined but not referenced. I suspect I added this bug...
